### PR TITLE
Update university-of-edinburgh-neuroscience.md

### DIFF
--- a/_journal-clubs/university-of-edinburgh-neuroscience.md
+++ b/_journal-clubs/university-of-edinburgh-neuroscience.md
@@ -1,5 +1,5 @@
 ---
-title: University of Edinburgh Neuroscience
+title: Edinburgh
 host-organisation: University of Edinburgh
 host-org-url: https://www.ed.ac.uk/
 osf: kh5px
@@ -15,4 +15,4 @@ country: United Kingdom
 geolocation: [55.92800001097837, -3.2141876220703125]
 ---
 
-Hi all! We are Niamh MacSweeney and Laura Klinkhamer from the Division of Psychiatry at the University of Edinburgh. With this JC we hope to promote open science practices across Edinburgh Neuroscience. Look forward to seeing you at our JCs!
+Hi all! We are Niamh MacSweeney and Laura Klinkhamer from the Division of Psychiatry at the University of Edinburgh. With this JC we hope to promote open science practices across the University. Look forward to seeing you at our JCs!


### PR DESCRIPTION
We have been asked to change our name to "Edinburgh" for easier accessibility. Also I changed part of description from Neuroscience to University as the initiative has now grown to be University-wide rather than Neuroscience-specific.