### PR TITLE
Updated organisers list and updated sign up sheet

### DIFF
--- a/_journal-clubs/university-of-edinburgh-neuroscience.md
+++ b/_journal-clubs/university-of-edinburgh-neuroscience.md
@@ -8,11 +8,11 @@ osf: kh5px
 zotero: NA9JUQF4
 website: https://edopenresearch.com/reproducibilitea-blog/
 twitter: https://twitter.com/Edinburgh_Tea
-signup: https://forms.gle/AuYXJtayYMc41T5j6
-organisers: [Laura Klinkhamer, Niamh MacSweeney, Emily Oxley, Sumbul Syed, Bérengère Digard, Amelie Voges]
+signup: https://docs.google.com/forms/d/e/1FAIpQLScjjpsLmzt-XIm21ec5sUz4LGE_YfOrjwnI321WcS5R5qgXFA/viewform
+organisers: [Sumbul Syed, Bérengère Digard]
 contact: Edinburgh.ReproducibiliTea@ed.ac.uk
 additional-contact: []
-address: [Division of Psychiatry, University of Edinburgh, 7th Floor Kennedy Tower, Royal Edinburgh Hospital, Morningside Park, Edinburgh EH10 5HF]
+address: [University of Edinburgh]
 country: United Kingdom
 geolocation: [55.92800001097837, -3.2141876220703125]
 last-message-timestamp: 1638201439
@@ -30,4 +30,4 @@ For an overview of our schedule and blog posts about our previous sessions see h
 
 We also have a YouTube channel were we upload our recordings https://www.youtube.com/channel/UC9y6VX6Dvs4-vC8eDuOKpNQ and we also post our recordings and other relevant materials on our OSF page: https://osf.io/kh5px/ 
 
-To sign up for our sessions you can join our mailing list by filling out this form https://forms.gle/AuYXJtayYMc41T5j6 or keep an eye on our Twitter (@Edinburgh_Tea) for links to our session-specific Eventbrite pages. We hope to see you at one of our sessions!
+To sign up for our sessions you can join our mailing list by filling out this form https://docs.google.com/forms/d/e/1FAIpQLScjjpsLmzt-XIm21ec5sUz4LGE_YfOrjwnI321WcS5R5qgXFA/viewform or keep an eye on our Twitter (@Edinburgh_Tea) for links to our session-specific Eventbrite pages. We hope to see you at one of our sessions!


### PR DESCRIPTION
We've now officially handed over to Sumbul and Bérengère and they have updated the sign-up sheet. I've also changed the address from the division of Psychiatry (where Niamh and I are based) to the more general University of Edinburgh location. The new organisers do not have a physical site at the moment.